### PR TITLE
Angular CLI font path fix

### DIFF
--- a/scss/_modals.scss
+++ b/scss/_modals.scss
@@ -63,7 +63,7 @@ body {
   }
   .modal-footer {
     border-top: 0;
-    padding-top: 0 24px 24px 24px;
+    padding: 0 24px 24px 24px;
   }
   .modal-fluid {
     width: 100%;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,6 +1,6 @@
 // Variables
 // Fonts
-$open-font-path: "../font/OpenSans/" !default;
+$open-font-path: "./../font/OpenSans/" !default;
 
 // Colors
 $warning-color:    #FFB900 !default;


### PR DESCRIPTION
When trying to compile with Angular CLI the path to fonts is somehow incorrectly translated. Adding the base path `./` fixes the issues (at least in my case).